### PR TITLE
Add demo binary, support detecting KDE Plasma 5 desktop environment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,12 @@ description = "Retrieve the current user and environment."
 keywords = ["user", "username", "whoami", "platform", "detect"]
 categories = ["os"]
 
+[lib]
+name = "whoami"
+path = "src/lib.rs"
+
+[[bin]]
+name = "whoami-demo"
+path = "src/main.rs"
+
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ fn main() {
 }
 ```
 
+You can also preview similar output with the `whoami-demo` binary.
+
 ## Features
 * Get the user's full name
 * Get the user's username

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,23 @@
+fn main() {
+    print!(
+        "whoami {} ({}, {})\n\n\
+         user's full name      whoami::user()       {}\n\
+         username              whoami::username()   {}\n\
+         host's fancy name     whoami::host()       {}\n\
+         hostname              whoami::hostname()   {}\n\
+         platform              whoami::platform()   {}\n\
+         operating system      whoami::os()         {}\n\
+         desktop environment   whoami::env()        {}\n\
+         ",
+        env!("CARGO_PKG_VERSION"),
+        env!("CARGO_PKG_AUTHORS"),
+        env!("CARGO_PKG_HOMEPAGE"),
+        whoami::user(),
+        whoami::username(),
+        whoami::host(),
+        whoami::hostname(),
+        whoami::platform(),
+        whoami::os(),
+        whoami::env(),
+    );
+}

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -236,9 +236,11 @@ pub const fn env() -> DesktopEnv {
 #[cfg(not(target_os = "macos"))]
 #[inline(always)]
 pub fn env() -> DesktopEnv {
-    match std::env::var_os("DESKTOP_SESSION") {
-        Some(env) => {
-            let env = env.to_str().unwrap().to_uppercase();
+    match std::env::var_os("DESKTOP_SESSION")
+        .map(|env| env.to_string_lossy().to_string())
+    {
+        Some(env_orig) => {
+            let env = env_orig.to_uppercase();
 
             if env.contains("GNOME") {
                 DesktopEnv::Gnome
@@ -250,8 +252,10 @@ pub fn env() -> DesktopEnv {
                 DesktopEnv::I3
             } else if env.contains("UBUNTU") {
                 DesktopEnv::Ubuntu
+            } else if env.contains("PLASMA5") {
+                DesktopEnv::Kde
             } else {
-                DesktopEnv::Unknown(env)
+                DesktopEnv::Unknown(env_orig)
             }
         }
         // TODO: Other Linux Desktop Environments


### PR DESCRIPTION
- On Unix, detect the KDE Plasma 5 desktop environment.
- If the desktop environment is unknown, return the `$DESKTOP_SESSION` environment variable unchanged, rather than all-uppercased (which likely makes the path invalid).
- Avoid unwrapping the environment variable as a string. It's unlikely but possible that an environment variable could have non-Unicode data in it.
- Add a `whoami-demo` binary to preview the crate's output:
  
```
$ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
     Running `target/debug/whoami-demo`
whoami 0.7.0 (Jeron Aldaron Lau <jeronlau@plopgrizzly.com>, https://libcala.github.io/whoami)

user's full name      whoami::user()       Rebecca Turner
username              whoami::username()   becca
host's fancy name     whoami::host()       Aquatica
hostname              whoami::hostname()   aquatica
platform              whoami::platform()   Linux
operating system      whoami::os()         NixOS 19.09.2079.8731aaaf8b3 (Loris)
desktop environment   whoami::env()        KDE
```