### PR TITLE
Check return value of getpwuid_r.

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -202,13 +202,17 @@ fn getpwuid(real: bool) -> Result<OsString, OsString> {
 
     // Get PassWd `struct`.
     let passwd = unsafe {
-        getpwuid_r(
+        let ret = getpwuid_r(
             geteuid(),
             passwd.as_mut_ptr(),
             buffer.as_mut_ptr() as *mut c_void,
             BUF_SIZE,
             _passwd.as_mut_ptr(),
         );
+
+        if ret != 0 {
+            return Ok("".to_string().into());
+        }
 
         passwd.assume_init()
     };


### PR DESCRIPTION
This adds a check for the return value when calling [getpwuid_r](https://linux.die.net/man/3/getpwuid).

There are situations where `getpwuid_r` returns non-zero on error, and also situations where it returns 0 but sets the `result` pointer to NULL. The former case was not being handled, but the latter case was. However if you're (un)lucky, `getpwuid_r` will return non-zero, but the pointer still happens to be null, in which case this issue won't be noticed.

This situation came up when running a statically linked binary inside a `FROM scratch` Docker container, where there's no /etc/passwd file.

Here's a repo that demonstrates the bug and the fix: https://github.com/adeschamps/whoami-bug