### PR TITLE
Fix seg fault when passwd entry is missing

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -217,6 +217,12 @@ fn getpwuid(real: bool) -> OsString {
             return "Unknown".to_string().into();
         }
 
+        let _passwd = _passwd.assume_init();
+
+        if _passwd.is_null() {
+            return "Unknown".to_string().into();
+        }
+
         passwd.assume_init()
     };
 


### PR DESCRIPTION
This PR fixes a seg-fault when the passwd for a user is missing. A more detailed explanation can be found in issue https://github.com/libcala/whoami/issues/32