### PR TITLE
Derive PartialEq and Eq for DesktopEnv and Platform

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ use std::ffi::OsString;
 
 /// Which Desktop Environment
 #[allow(missing_docs)]
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum DesktopEnv {
     Gnome,
@@ -135,7 +135,7 @@ impl std::fmt::Display for DesktopEnv {
 
 /// Which Platform
 #[allow(missing_docs)]
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Platform {
     Linux,


### PR DESCRIPTION
<!--- Please describe the changes in the PR and the motivation below -->
<!--- Check CONTRIBUTING.md for more information-->

I'm working on a little project where I use the `Platform` struct to check which OS I am on, but right now it is a little cumbersome since I can't compare the enum variants themselves. You should also consider deriving `Copy` on both `Platform` and `DesktopEnv`: https://doc.rust-lang.org/std/marker/trait.Copy.html#when-should-my-type-be-copy.